### PR TITLE
Retrofit RON to run via Docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+.git
+__pycache__
+*.pyo
+*.pyd

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,83 @@
+name: Docker Build
+on:
+  push:
+    branches:
+      - '**'
+    tags:
+      - 'v*.*.*'
+  release:
+    types: [ published ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+    steps:
+      - name: Ensure repo name is lowercase
+        run: |
+          echo "REPO=${GITHUB_REPOSITORY@L}" >> "${GITHUB_ENV}"
+
+      - name: Ensure branch/tag name is Docker-friendly
+        run: |
+          export REPLACE="/"
+          export REPLACEWITH="_"
+          echo "REF=${GITHUB_REF_NAME//${REPLACE}/${REPLACEWITH}}" >> "${GITHUB_ENV}"
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Login to GitHub Packages
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # Triggered by every commit
+      # Creates images for the commit's hash and branch name
+      - name: Push to commit hash and branch name
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          platforms: linux/amd64,linux/arm64
+          build-args: |
+            version=${{ env.REF }}
+            revision=${{ github.sha }}
+          tags: ghcr.io/${{ env.REPO }}:${{ github.sha }},ghcr.io/${{ env.REPO }}:${{ env.REF }}
+        if: ${{ github.ref_type == 'branch' }}
+
+      # Only triggered by commits to tags
+      # Creates images for the tag name only
+      - name: Push to tag name only
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          platforms: linux/amd64,linux/arm64
+          build-args: |
+            version=${{ env.REF }}
+            revision=${{ github.sha }}
+          tags: ghcr.io/${{ env.REPO }}:${{ env.REF }}
+        if: ${{ github.ref_type == 'tag' && github.event_name == 'push' }}
+
+      # Only triggered when a release is published
+      # Creates images for the tag name and the latest tag
+      - name: Push to tag name and latest
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          platforms: linux/amd64,linux/arm64
+          build-args: |
+            version=${{ env.REF }}
+            revision=${{ github.sha }}
+          tags: ghcr.io/${{ env.REPO }}:${{ env.REF }},ghcr.io/${{ env.REPO }}:latest
+        if: ${{ github.event_name == 'release' }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+FROM python:3.10-slim
+
+WORKDIR /app
+
+# Update pip, install dependencies and delete cache
+COPY requirements.txt .
+RUN pip install --upgrade pip && \
+    pip install -r requirements.txt && \
+    rm -rf ~/.cache/pip
+
+# Install system dependencies
+RUN apt update && \
+    apt install -y \
+      ca-certificates # Installs root certificates for known certificate authorities
+
+# Copy over the application code and set the command to run it
+COPY . /app
+CMD ["python", "main.py"]

--- a/compose.yml
+++ b/compose.yml
@@ -1,0 +1,11 @@
+name: ron
+
+services:
+  ron:
+    container_name: ron
+    image: ghcr.io/slugsoc/slugs-discord-bot:latest
+    volumes:
+      - ./token.yaml:/app/token.yaml
+      - ./logs:/app/logs
+      - ./server_configs:/app/server_configs
+    restart: unless-stopped

--- a/dockerfile
+++ b/dockerfile
@@ -1,5 +1,0 @@
-FROM python:3.12
-COPY . /app
-WORKDIR /app
-RUN pip install -r requirements.txt
-CMD ["python", "/app/main.py"]

--- a/dockerfile
+++ b/dockerfile
@@ -1,0 +1,5 @@
+FROM python:3.12
+COPY . /app
+WORKDIR /app
+RUN pip install -r requirements.txt
+CMD ["python", "/app/main.py"]


### PR DESCRIPTION
This PR does the following:

- Creates an optimised Dockerfile
- Adds an exemplary Docker `compose.yml` file
- Adds a GitHub Workflow to automatically build a Docker image whenever changes are made and publish it to the GitHub Container Repo

## Notes on the GitHub Workflow

The workflow is triggered on a push to any branch or tag and when new releases are published. The Docker image that is built will be tagged as follows:

- The release name and `latest` when a release is published
- The tag name for pushes to a tag
- The branch name and full commit hash on pushes to a branch